### PR TITLE
fix: Apply bug fixes from issues #12-15 without broken refactoring

### DIFF
--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -426,7 +426,11 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
 
                 # saving cadence frames
                 filename = f"{root.timestring}_{tween_frame_idx:09}.png"
-                cv2.imwrite(os.path.join(args.outdir, filename), img)
+                # Validate image before saving to prevent OpenCV assertion errors
+                if img is not None and hasattr(img, 'shape') and img.size > 0:
+                    cv2.imwrite(os.path.join(args.outdir, filename), img)
+                else:
+                    print(f"Warning: Skipping save for frame {tween_frame_idx} - invalid or empty image")
                 if anim_args.save_depth_maps:
                     depth_model.save(os.path.join(args.outdir, f"{root.timestring}_depth_{tween_frame_idx:09}.png"), depth)
 

--- a/scripts/deforum_helpers/rendering/data/shakify/shaker.py
+++ b/scripts/deforum_helpers/rendering/data/shakify/shaker.py
@@ -37,7 +37,7 @@ class Shaker:
     @staticmethod
     def is_enabled(data: 'RenderData'):
         aa = data.args.anim_args
-        return aa.shake_name and aa.shake_name != 'None'
+        return aa.shake_name and aa.shake_name != 'None' and aa.shake_name != '' and aa.shake_name is not None
 
     @staticmethod
     def create(data: 'RenderData') -> 'Shaker':
@@ -52,10 +52,10 @@ class Shaker:
 
         log_utils.info(f"Calculating shake '{shake_name}' at intensity {intensity} with speed {speed}.")
         shake_key = Shaker.shake_name_to_key(shake_name)
-        if shake_key is None:
+        if shake_key is None or shake_key not in SHAKE_LIST:
             log_utils.warn(f"Camera shake name '{shake_name}' not found! Defaulting to 'None'. Valid options are: {list(get_camera_shake_list().values())}")
             return Shaker('None', 1.0, 1.0, {}, False)
-        
+
         name, source_fps, shake_data = SHAKE_LIST[shake_key]
 
         def _proc(key, xyz):

--- a/scripts/deforum_helpers/save_images.py
+++ b/scripts/deforum_helpers/save_images.py
@@ -39,7 +39,16 @@ def reset_frames_cache(root):
 def dump_frames_cache(root):
     for image_cache in root.frames_cache:
         if image_cache['image_type'] == 'cv2':
-            cv2.imwrite(image_cache['path'], image_cache['image'])
+            img = image_cache['image']
+            # Validate image before saving to prevent OpenCV assertion errors
+            if img is not None and hasattr(img, 'shape') and img.size > 0:
+                cv2.imwrite(image_cache['path'], img)
+            else:
+                print(f"Warning: Skipping save for {image_cache['path']} - invalid or empty image")
         elif image_cache['image_type'] == 'PIL':
-            image_cache['image'].save(image_cache['path'])
+            img = image_cache['image']
+            if img is not None:
+                img.save(image_cache['path'])
+            else:
+                print(f"Warning: Skipping save for {image_cache['path']} - invalid or empty image")
     # do not reset the cache since we're going to add frame erasing later function #TODO 


### PR DESCRIPTION
## Summary

This PR applies the essential bug fixes from issues #12-15 to the main branch **without** the massive refactoring that broke everything.

## Background

The `hotfix/github-issues-12-15` branch contained 438 changed files with 200+ commits of refactoring that introduced critical bugs. Instead of trying to salvage that, we:

1. ✅ Tagged the failed attempt as `failed-refactor-attempt`
2. ✅ Created fresh branch from working `main`
3. ✅ Applied **only the actual bug fixes** to main's file structure

## Changes

### Issue #13: Camera Shake KeyError
**File:** `scripts/deforum_helpers/rendering/data/shakify/shaker.py`
- Enhanced validation for `shake_name` 
- Checks for `None`, empty strings, and existence in `SHAKE_LIST`
- Prevents Google Colab crashes with invalid shake patterns

### Issue #12: OpenCV Assertion Error  
**Files:** 
- `scripts/deforum_helpers/save_images.py`
- `scripts/deforum_helpers/render.py`

- Added image validation before `cv2.imwrite()` calls
- Validates images have valid shape and size
- Prevents crashes with Parseq or invalid/empty images

### Issue #15: Wan Import Error
- Not applicable - only existed in refactored code structure

### Issue #14: UI Tabs Error
- Not applicable - already fixed in current main branch

## Testing

✅ Basic generation confirmed working after applying fixes

## What We Avoided

By skipping the broken refactoring:
- ❌ 438 file changes
- ❌ 200+ commits of file moves
- ❌ Broken experimental rendering core
- ❌ Missing generation functions
- ❌ Broken schedule parsing
- ❌ Steps schedule returning None

## Result

Clean, minimal fix that solves the actual bugs without introducing new ones.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>