### PR TITLE
fix: strip inline comments from requirements.txt lines before pip install (closes #25)

### DIFF
--- a/install.py
+++ b/install.py
@@ -22,6 +22,9 @@ req_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requiremen
 with open(req_file) as file:
     for lib in file:
         lib = lib.strip()
+        # Remove inline comments
+        if '#' in lib:
+            lib = lib[:lib.index('#')].strip()
         if not lib or lib.startswith('#'):
             continue
         


### PR DESCRIPTION
## What
When `requirements.txt` contains lines with inline comments (e.g., `sentencepiece>=0.1.99  # Required by T5Tokenizer (LTX-2)`), the comment is passed directly to pip on the command line. pip does not support inline comments in command-line arguments, causing it to fail with `ERROR: Invalid requirement: '#': Expected package name at the start of dependency specifier`.

This causes `install.py` to crash with error code 1, preventing the extension tab from appearing in SD Forge Neo.

## Fix
Strip inline comments (anything after `#`) from each requirement line before passing it to pip.

Closes #25